### PR TITLE
Use Java collection interfaces rather than specific implementation

### DIFF
--- a/src/main/java/net/seninp/jmotif/cluster/Cluster.java
+++ b/src/main/java/net/seninp/jmotif/cluster/Cluster.java
@@ -4,6 +4,7 @@ import java.text.DecimalFormat;
 import java.text.DecimalFormatSymbols;
 import java.util.Arrays;
 import java.util.HashMap;
+import java.util.Map;
 import java.util.TreeSet;
 import net.seninp.jmotif.text.CosineDistanceMatrix;
 
@@ -72,7 +73,7 @@ public class Cluster {
    * @param criterion The linkage criterion.
    * @return The distance between clusters based on the distances and the linkage.
    */
-  public Double distanceTo(Cluster otherCluster, HashMap<String, HashMap<String, Double>> data,
+  public Double distanceTo(Cluster otherCluster, Map<String, HashMap<String, Double>> data,
       CosineDistanceMatrix distanceMatrix, LinkageCriterion criterion) {
     if (otherCluster.keys.size() == 1 && this.keys.size() == 1) {
       return distanceMatrix.distanceBetween(otherCluster.keys.first(), this.keys.first());

--- a/src/main/java/net/seninp/jmotif/cluster/FurthestFirstStrategy.java
+++ b/src/main/java/net/seninp/jmotif/cluster/FurthestFirstStrategy.java
@@ -4,6 +4,7 @@ import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.Map.Entry;
 import java.util.Random;
+import java.util.Set;
 import java.util.TreeSet;
 import net.seninp.jmotif.text.CosineDistanceMatrix;
 
@@ -83,7 +84,7 @@ public class FurthestFirstStrategy implements StartStrategy {
    * @param matrix
    * @return
    */
-  private double minCosineDistance(String furthestElement, TreeSet<String> resultKeys,
+  private double minCosineDistance(String furthestElement, Set<String> resultKeys,
       CosineDistanceMatrix matrix) {
     double minDist = 0.0D;
     for (String currKey : resultKeys) {

--- a/src/main/java/net/seninp/jmotif/cluster/RandomStartStrategy.java
+++ b/src/main/java/net/seninp/jmotif/cluster/RandomStartStrategy.java
@@ -35,9 +35,9 @@ public class RandomStartStrategy implements StartStrategy {
 
     Random random = new Random();
 
-    LinkedHashMap<String, HashMap<String, Double>> res = new LinkedHashMap<String, HashMap<String, Double>>();
+    LinkedHashMap<String, HashMap<String, Double>> res = new LinkedHashMap<>();
 
-    ArrayList<String> keys = new ArrayList<String>();
+    ArrayList<String> keys = new ArrayList<>();
     for (String k : data.keySet()) {
       keys.add(k.substring(0));
     }
@@ -49,7 +49,7 @@ public class RandomStartStrategy implements StartStrategy {
       keys.remove(rand);
       consoleLogger.info("random cluster " + i + ", center: " + key);
 
-      HashMap<String, Double> value = new HashMap<String, Double>();
+      HashMap<String, Double> value = new HashMap<>();
       for (Entry<String, Double> e : data.get(key).entrySet()) {
         value.put(e.getKey().substring(0), new Double(e.getValue()));
       }

--- a/src/main/java/net/seninp/jmotif/cluster/TextKMeans.java
+++ b/src/main/java/net/seninp/jmotif/cluster/TextKMeans.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Map.Entry;
 import net.seninp.jmotif.text.CosineDistanceMatrix;
 import net.seninp.jmotif.text.TextProcessor;
@@ -82,8 +83,8 @@ public class TextKMeans {
     return tp.tfidfToTable(centroids).toCharArray();
   }
 
-  private static double computeIntraSS(HashMap<String, HashMap<String, Double>> tfidf,
-      HashMap<String, List<String>> clusters) {
+  private static double computeIntraSS(Map<String, HashMap<String, Double>> tfidf,
+      Map<String, List<String>> clusters) {
     double res = 0;
     for (Entry<String, List<String>> e : clusters.entrySet()) {
       for (int i = 0; i < e.getValue().size(); i++) {
@@ -98,8 +99,8 @@ public class TextKMeans {
     return res;
   }
 
-  private static boolean updateCentroids(LinkedHashMap<String, HashMap<String, Double>> centroids,
-      HashMap<String, List<String>> clusters, HashMap<String, HashMap<String, Double>> tfidf) {
+  private static boolean updateCentroids(Map<String, HashMap<String, Double>> centroids,
+                                         Map<String, List<String>> clusters, HashMap<String, HashMap<String, Double>> tfidf) {
 
     boolean res = false;
 
@@ -125,7 +126,7 @@ public class TextKMeans {
    * @return
    */
   public static HashMap<String, Double> computeCentroid(
-      HashMap<String, HashMap<String, Double>> tfidf, List<String> members) {
+          Map<String, HashMap<String, Double>> tfidf, List<String> members) {
 
     // extract the list of all words into a new bag
     //
@@ -158,8 +159,8 @@ public class TextKMeans {
    * @return
    */
   private static HashMap<String, List<String>> clusterize(
-      LinkedHashMap<String, HashMap<String, Double>> centroids,
-      HashMap<String, HashMap<String, Double>> tfidf) {
+      Map<String, HashMap<String, Double>> centroids,
+      Map<String, HashMap<String, Double>> tfidf) {
 
     // build centroids
     //

--- a/src/main/java/net/seninp/jmotif/direct/SAXVSMCVErrorFunction.java
+++ b/src/main/java/net/seninp/jmotif/direct/SAXVSMCVErrorFunction.java
@@ -109,10 +109,10 @@ public class SAXVSMCVErrorFunction implements AbstractErrorFunction {
       consoleLogger.debug(params.toString());
 
       // cache for word bags
-      HashMap<String, WordBag> seriesBags = new HashMap<String, WordBag>();
+      Map<String, WordBag> seriesBags = new HashMap<String, WordBag>();
 
       // the class series bags
-      HashMap<String, WordBag> bags = new HashMap<String, WordBag>();
+      Map<String, WordBag> bags = new HashMap<String, WordBag>();
 
       // push into stack all the samples we are going to validate for
       Stack<String> samples2go = new Stack<String>();
@@ -175,7 +175,7 @@ public class SAXVSMCVErrorFunction implements AbstractErrorFunction {
 
         // adjust word bags
         //
-        HashMap<String, WordBag> basisBags = adjustWordBags(bags, wordsToRemove);
+        Map<String, WordBag> basisBags = adjustWordBags(bags, wordsToRemove);
 
         // validation phase
         //
@@ -210,8 +210,8 @@ public class SAXVSMCVErrorFunction implements AbstractErrorFunction {
 
   }
 
-  private HashMap<String, WordBag> adjustWordBags(HashMap<String, WordBag> bags,
-      HashMap<String, WordBag> wordsToRemove) {
+  private HashMap<String, WordBag> adjustWordBags(Map<String, WordBag> bags,
+      Map<String, WordBag> wordsToRemove) {
 
     HashMap<String, WordBag> res = new HashMap<String, WordBag>();
     for (Entry<String, WordBag> e : bags.entrySet()) {

--- a/src/main/java/net/seninp/jmotif/direct/SAXVSMDirectSampler.java
+++ b/src/main/java/net/seninp/jmotif/direct/SAXVSMDirectSampler.java
@@ -12,6 +12,8 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Set;
+
 import net.seninp.jmotif.sax.NumerosityReductionStrategy;
 import net.seninp.jmotif.sax.SAXProcessor;
 import net.seninp.jmotif.text.Params;
@@ -40,10 +42,10 @@ public class SAXVSMDirectSampler {
   private static DecimalFormat fmt = new DecimalFormat("0.00###", otherSymbols);
 
   // array with all rectangle centerpoints
-  private static ArrayList<Double[]> centerPoints;
+  private static List<Double[]> centerPoints;
 
   // array with all rectangle side lengths in each dimension
-  private static ArrayList<Double[]> lengthsSide;
+  private static List<Double[]> lengthsSide;
 
   // array with distances from center points to the vertices
   private static ArrayList<Double> diagonalLength;
@@ -58,7 +60,7 @@ public class SAXVSMDirectSampler {
   private static ArrayList<Double> functionValues;
 
   // array used to track sampled points and function values
-  private static ArrayList<ValuePointColored> coordinates;
+  private static List<ValuePointColored> coordinates;
   private static HashMap<String, Double> functionHash;
 
   private static final double precision = 1E-16;
@@ -331,7 +333,7 @@ public class SAXVSMDirectSampler {
     // generally, we want a shorter window
     //
     StringBuffer sb = new StringBuffer();
-    HashSet<String> minimalValueParameters = new HashSet<String>();
+    Set<String> minimalValueParameters = new HashSet<String>();
     double minimalValue = resultMinimum[0];
 
     sb.append("min CV error ").append(fmt.format(minimalValue)).append(" reached at ");
@@ -411,7 +413,7 @@ public class SAXVSMDirectSampler {
     while (true) {
       double diagonalTmp = differentDiagonalLength.get(i1);
       Integer[] indx = findNonMatches(differentDiagonalLength, diagonalTmp);
-      ArrayList<Double> diagonalCopy = differentDiagonalLength;
+      List<Double> diagonalCopy = differentDiagonalLength;
       differentDiagonalLength = new ArrayList<Double>();
       differentDiagonalLength.add(diagonalTmp);
 
@@ -545,7 +547,7 @@ public class SAXVSMDirectSampler {
 
   }
 
-  private static void saveCache(Point point, Double value, HashMap<String, Double> cache) {
+  private static void saveCache(Point point, Double value, Map<String, Double> cache) {
     // formatting the string
     StringBuffer sb = new StringBuffer();
     for (double d : point.toArray()) {
@@ -556,7 +558,7 @@ public class SAXVSMDirectSampler {
     // consoleLogger.info(sb.toString() + ", " + value);
   }
 
-  private static Double checkCache(Point point, HashMap<String, Double> cache) {
+  private static Double checkCache(Point point, Map<String, Double> cache) {
     // formatting the string
     StringBuffer sb = new StringBuffer();
     for (double d : point.toArray()) {
@@ -662,7 +664,7 @@ public class SAXVSMDirectSampler {
 
     // s_1 now includes all rectangles i, with diagonals[i] >= diagonals(indexPotentialBestRec)
     //
-    ArrayList<Integer> s_2 = new ArrayList<Integer>();
+    List<Integer> s_2 = new ArrayList<Integer>();
     ArrayList<Integer> s_3 = new ArrayList<Integer>();
     if (differentDiagonalLength.size() - sameDiagonalIdxs[0] > 2) {
 

--- a/src/main/java/net/seninp/jmotif/direct/SAXVSMPatternExplorer.java
+++ b/src/main/java/net/seninp/jmotif/direct/SAXVSMPatternExplorer.java
@@ -123,7 +123,7 @@ public class SAXVSMPatternExplorer {
     // sort words by their weight and print top 10 of these for each class
     for (Entry<String, HashMap<String, Double>> e : tfidf.entrySet()) {
       String className = e.getKey();
-      ArrayList<Entry<String, Double>> values = new ArrayList<Entry<String, Double>>();
+      List<Entry<String, Double>> values = new ArrayList<Entry<String, Double>>();
       values.addAll(e.getValue().entrySet());
 
       Collections.sort(values, new TfIdfEntryComparator());
@@ -145,7 +145,7 @@ public class SAXVSMPatternExplorer {
 
       // class name and weights vector
       String className = e.getKey();
-      ArrayList<Entry<String, Double>> values = new ArrayList<Entry<String, Double>>();
+      List<Entry<String, Double>> values = new ArrayList<Entry<String, Double>>();
       values.addAll(e.getValue().entrySet());
 
       // form the output
@@ -204,7 +204,7 @@ public class SAXVSMPatternExplorer {
   }
 
   private static double[] seriesValuesAsHeat(double[] series, String className,
-      HashMap<String, HashMap<String, Double>> tfidf, Params params) throws Exception {
+                                             Map<String, HashMap<String, Double>> tfidf, Params params) throws Exception {
 
     Alphabet a = new NormalAlphabet();
 

--- a/src/main/java/net/seninp/jmotif/text/CosineDistanceMatrix.java
+++ b/src/main/java/net/seninp/jmotif/text/CosineDistanceMatrix.java
@@ -4,6 +4,7 @@ import java.text.DecimalFormat;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Locale;
+import java.util.Map;
 
 /**
  * Implements cosine distance matrix.
@@ -32,7 +33,7 @@ public class CosineDistanceMatrix {
    * 
    * @param tfidf The data to use.
    */
-  public CosineDistanceMatrix(HashMap<String, HashMap<String, Double>> tfidf) {
+  public CosineDistanceMatrix(Map<String, HashMap<String, Double>> tfidf) {
 
     Locale.setDefault(Locale.US);
 

--- a/src/main/java/net/seninp/jmotif/text/TextProcessor.java
+++ b/src/main/java/net/seninp/jmotif/text/TextProcessor.java
@@ -150,7 +150,7 @@ public final class TextProcessor {
     HashMap<String, HashMap<String, Double>> res = new HashMap<String, HashMap<String, Double>>();
 
     // build a collection of all observed words and their frequency in corpus
-    HashMap<String, AtomicInteger> allWords = new HashMap<String, AtomicInteger>();
+    Map<String, AtomicInteger> allWords = new HashMap<String, AtomicInteger>();
     for (WordBag bag : texts) {
 
       // here populate result map with empty entries
@@ -174,7 +174,7 @@ public final class TextProcessor {
 
       // fix the doc name
       String bagName = bag.getLabel();
-      HashMap<String, AtomicInteger> bagWords = bag.getInternalWords(); // these are words of
+      Map<String, AtomicInteger> bagWords = bag.getInternalWords(); // these are words of
                                                                         // documents
 
       // what we want to do for TF*IDF is to compute it for all WORDS ever seen in set
@@ -297,7 +297,7 @@ public final class TextProcessor {
    * @param string The string term.
    * @return The DF value.
    */
-  public int df(HashMap<String, WordBag> bags, String string) {
+  public int df(Map<String, WordBag> bags, String string) {
     int res = 0;
     for (WordBag b : bags.values()) {
       if (b.contains(string)) {
@@ -319,12 +319,12 @@ public final class TextProcessor {
         / Integer.valueOf(df(bags, string)).doubleValue();
   }
 
-  public String tfidfToTable(HashMap<String, HashMap<String, Double>> tfidf) {
+  public String tfidfToTable(Map<String, HashMap<String, Double>> tfidf) {
 
     // melt together sets of keys
     //
-    TreeSet<String> words = new TreeSet<String>();
-    for (HashMap<String, Double> t : tfidf.values()) {
+    Set<String> words = new TreeSet<String>();
+    for (Map<String, Double> t : tfidf.values()) {
       words.addAll(t.keySet());
     }
 
@@ -345,7 +345,7 @@ public final class TextProcessor {
       rowSB.append("\"").append(w).append("\",");
 
       for (String key : tfidf.keySet()) {
-        HashMap<String, Double> data = tfidf.get(key);
+        Map<String, Double> data = tfidf.get(key);
 
         if (data.keySet().contains(w)) {
           rowSB.append(data.get(w)).append(",");
@@ -376,7 +376,7 @@ public final class TextProcessor {
    * @param vector the vector.
    * @return normalized vector.
    */
-  public HashMap<String, Double> normalizeToUnitVector(HashMap<String, Double> vector) {
+  public HashMap<String, Double> normalizeToUnitVector(Map<String, Double> vector) {
     double sum = 0d;
     for (double value : vector.values()) {
       sum = sum + value * value;
@@ -396,7 +396,7 @@ public final class TextProcessor {
    * @return The normalized tfidf statistics.
    */
   public HashMap<String, HashMap<String, Double>> normalizeToUnitVectors(
-      HashMap<String, HashMap<String, Double>> data) {
+      Map<String, HashMap<String, Double>> data) {
     // result
     HashMap<String, HashMap<String, Double>> res = new HashMap<String, HashMap<String, Double>>();
     // cosine normalize these rows corresponding to docs TFIDF
@@ -438,7 +438,7 @@ public final class TextProcessor {
    * @param map2 The data vector 2.
    * @return The cosine distance.
    */
-  public double cosineDistance(HashMap<String, Double> map1, HashMap<String, Double> map2) {
+  public double cosineDistance(Map<String, Double> map1, Map<String, Double> map2) {
 
     Set<String> unionKey = map2.keySet();
     if (!(map1.keySet().equals(map2.keySet()))) {
@@ -466,7 +466,7 @@ public final class TextProcessor {
     return numerator / denominator;
   }
 
-  public double cosineSimilarity(WordBag testSample, HashMap<String, Double> weightVector) {
+  public double cosineSimilarity(WordBag testSample, Map<String, Double> weightVector) {
     double res = 0;
     for (Entry<String, Integer> entry : testSample.getWords().entrySet()) {
       if (weightVector.containsKey(entry.getKey())) {
@@ -516,7 +516,7 @@ public final class TextProcessor {
   }
 
   public double cosineSimilarityInstrumented(WordBag testSample,
-      HashMap<String, Double> weightVector, HashMap<String, Double> insight) {
+                                             Map<String, Double> weightVector, Map<String, Double> insight) {
     double res = 0;
     for (Entry<String, Integer> entry : testSample.getWords().entrySet()) {
       if (weightVector.containsKey(entry.getKey())) {
@@ -647,7 +647,7 @@ public final class TextProcessor {
   }
 
   public int classify(String trueClassLabel, WordBag test,
-      HashMap<String, HashMap<String, Double>> tfidf, Params params) {
+                      Map<String, HashMap<String, Double>> tfidf, Params params) {
 
     // it is Cosine similarity,
     //
@@ -691,7 +691,7 @@ public final class TextProcessor {
     return 0;
   }
 
-  public String classify(WordBag test, HashMap<String, HashMap<String, Double>> tfidf) {
+  public String classify(WordBag test, Map<String, HashMap<String, Double>> tfidf) {
 
     // it is Cosine similarity,
     //
@@ -817,7 +817,7 @@ public final class TextProcessor {
 
   public String wordBagToTable(WordBag bag) {
 
-    TreeSet<String> words = new TreeSet<String>();
+    Set<String> words = new TreeSet<String>();
     words.addAll(bag.getWordSet());
 
     // name
@@ -844,14 +844,14 @@ public final class TextProcessor {
 
     // melt together sets of keys
     //
-    TreeSet<String> words = new TreeSet<String>();
+    Set<String> words = new TreeSet<String>();
     for (WordBag bag : bags) {
       words.addAll(bag.getWordSet());
     }
 
     // print keys - the dictionaries names
     //
-    LinkedHashMap<String, Integer> bagKeys = new LinkedHashMap<String, Integer>();
+    Map<String, Integer> bagKeys = new LinkedHashMap<String, Integer>();
     StringBuilder sb = new StringBuilder("\"\",");
     int index = 0;
     for (WordBag bag : bags) {
@@ -871,7 +871,7 @@ public final class TextProcessor {
 
       for (Entry<String, Integer> bagKey : bagKeys.entrySet()) {
         WordBag bag = bags.get(bagKey.getValue());
-        HashMap<String, Integer> data = bag.getWords();
+        Map<String, Integer> data = bag.getWords();
 
         if (data.keySet().contains(w)) {
           rowSB.append(data.get(w)).append(",");

--- a/src/main/java/net/seninp/jmotif/text/WordBag.java
+++ b/src/main/java/net/seninp/jmotif/text/WordBag.java
@@ -2,6 +2,7 @@ package net.seninp.jmotif.text;
 
 import java.util.Collection;
 import java.util.HashMap;
+import java.util.Map;
 import java.util.Map.Entry;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -38,7 +39,7 @@ public class WordBag implements Cloneable {
    * @param bagName The name for the collection.
    * @param words The words data for the collection.
    */
-  public WordBag(String bagName, HashMap<String, Integer> words) {
+  public WordBag(String bagName, Map<String, Integer> words) {
     this.label = bagName;
     this.words = new HashMap<String, AtomicInteger>();
     for (Entry<String, Integer> e : words.entrySet()) {


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S1319 - “Declarations should use Java collection interfaces such as "List" rather than specific implementation classes such as "LinkedList" ”. You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1319
Please let me know if you have any questions.
Ayman Abdelghany.
