### PR TITLE
Utility classes should not have public constructors

### DIFF
--- a/src/main/java/net/seninp/jmotif/SAXVSMClassifier.java
+++ b/src/main/java/net/seninp/jmotif/SAXVSMClassifier.java
@@ -46,6 +46,9 @@ public class SAXVSMClassifier {
     consoleLogger.setLevel(LOGGING_LEVEL);
   }
 
+  private SAXVSMClassifier() {
+  }
+
   public static void main(String[] args) throws SAXException{
 
     try {

--- a/src/main/java/net/seninp/jmotif/cluster/ClusterUtils.java
+++ b/src/main/java/net/seninp/jmotif/cluster/ClusterUtils.java
@@ -10,6 +10,9 @@ public class ClusterUtils {
   private static final String CR = "\n";
   private static final DecimalFormat df = new DecimalFormat("#0.00000");
 
+  private ClusterUtils() {
+  }
+
   public static String centroidsToString(LinkedHashMap<String, HashMap<String, Double>> centroids) {
 
     StringBuffer res = new StringBuffer();

--- a/src/main/java/net/seninp/jmotif/cluster/TextKMeans.java
+++ b/src/main/java/net/seninp/jmotif/cluster/TextKMeans.java
@@ -29,6 +29,9 @@ public class TextKMeans {
     consoleLogger.setLevel(LOGGING_LEVEL);
   }
 
+  private TextKMeans() {
+  }
+
   /**
    * This clusters a map data structure of pairs bagName wordBag which is used as tfidf throughout
    * of JMotif.

--- a/src/main/java/net/seninp/jmotif/direct/GoldsteinPriceFunction.java
+++ b/src/main/java/net/seninp/jmotif/direct/GoldsteinPriceFunction.java
@@ -11,6 +11,9 @@ package net.seninp.jmotif.direct;
  */
 public class GoldsteinPriceFunction {
 
+  private GoldsteinPriceFunction() {
+  }
+
   public static double compute(double x1, double x2) {
 
     double z1 = x1 / 10;

--- a/src/main/java/net/seninp/jmotif/direct/GoldsteinPriceFunctionSampler.java
+++ b/src/main/java/net/seninp/jmotif/direct/GoldsteinPriceFunctionSampler.java
@@ -19,6 +19,9 @@ public class GoldsteinPriceFunctionSampler {
 
   private static final double step = 0.5;
 
+  private GoldsteinPriceFunctionSampler() {
+  }
+
   public static void main(String[] args) {
 
     double x1 = X1_START;

--- a/src/main/java/net/seninp/jmotif/direct/SAXVSMDirectSampler.java
+++ b/src/main/java/net/seninp/jmotif/direct/SAXVSMDirectSampler.java
@@ -101,6 +101,9 @@ public class SAXVSMDirectSampler {
 
   private static TextProcessor tp = new TextProcessor();
 
+  private SAXVSMDirectSampler() {
+  }
+
   public static void main(String[] args) throws Exception {
 
     try {

--- a/src/main/java/net/seninp/jmotif/direct/SAXVSMPatternExplorer.java
+++ b/src/main/java/net/seninp/jmotif/direct/SAXVSMPatternExplorer.java
@@ -70,6 +70,9 @@ public class SAXVSMPatternExplorer {
     consoleLogger.setLevel(LOGGING_LEVEL);
   }
 
+  private SAXVSMPatternExplorer() {
+  }
+
   /**
    * @param args
    * @throws Exception

--- a/src/main/java/net/seninp/jmotif/direct/ShubertFunction.java
+++ b/src/main/java/net/seninp/jmotif/direct/ShubertFunction.java
@@ -11,6 +11,9 @@ package net.seninp.jmotif.direct;
  */
 public class ShubertFunction {
 
+  private ShubertFunction() {
+  }
+
   public static double compute(double x1, double x2) {
 
     double p1 = 0.0;

--- a/src/test/java/net/seninp/jmotif/cluster/TestTextKMeans.java
+++ b/src/test/java/net/seninp/jmotif/cluster/TestTextKMeans.java
@@ -25,6 +25,9 @@ public class TestTextKMeans {
 
   private static final TextProcessor tp = new TextProcessor();
 
+  private TestTextKMeans() {
+  }
+
   public static void main(String[] args) throws Exception {
 
     HashMap<String, HashMap<String, Double>> tfidf = new HashMap<String, HashMap<String, Double>>();


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S1118 - “Utility classes should not have public constructors ”. You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1118
Please let me know if you have any questions.
Ayman Abdelghany.
